### PR TITLE
fix error with module import in normalize-url

### DIFF
--- a/config.client.js
+++ b/config.client.js
@@ -121,6 +121,9 @@ module.exports = ({config, baseUrl, entry, cpus}) => {
             // in axios's package.json another exports config is used for this path. As result this import is correct
             // for Webpack 4 and incorrect for Webpack 5 with default config (exportsFields: ['exports'])
             exportsFields: [],
+            fallback: {
+                url: require.resolve('url/'),
+            },
             alias,
             modules: [
                 config.sourcePath,

--- a/config.server.js
+++ b/config.server.js
@@ -67,6 +67,9 @@ module.exports = ({config, baseUrl, cpus}) => {
             // in axios's package.json another exports config is used for this path. As result this import is correct
             // for Webpack 4 and incorrect for Webpack 5 with default config (exportsFields: ['exports'])
             exportsFields: [],
+            fallback: {
+                url: require.resolve('url/'),
+            },
             alias: {
                 app: path.resolve(config.cwd, 'app'),
                 reducers: fs.existsSync(path.resolve(config.sourcePath, 'reducers'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/webpack",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "",
   "main": "index.js",
   "author": "Vladimir Kozhin <hello@kozhindev.com>",
@@ -62,6 +62,7 @@
     "terser-webpack-plugin": "^5.3.10",
     "thread-loader": "^4.0.2",
     "ts-loader": "^9.5.1",
+    "url": "^0.11.3",
     "webpack": "^5.90.3",
     "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^5.1.4",


### PR DESCRIPTION
при запуске проекта в дев-режиме с последней версией @steroids/react-webpack появлялась ошибка

<img width="1080" alt="Снимок экрана 2024-04-01 в 18 31 36" src="https://github.com/steroids/react-webpack/assets/33594661/a6125dde-1d34-400f-a378-f14e5f1ac8d7">

добавлены необходимые конфиги и пакет в зависимости, которые фиксят эту ошибку